### PR TITLE
change textRegex so it matches non-ascii

### DIFF
--- a/src-content/lib/word.js
+++ b/src-content/lib/word.js
@@ -1,4 +1,4 @@
-const textRegex = /\w/g
+const textRegex = /[^\s,.?:;"'`><+=&*()_-]/g
 const numRegex = /\d/g
 
 export default class Word {


### PR DESCRIPTION
textRegex was set to \w which matches ASCII characters only. This resulted in first latter being highlighted for all Thai, Russian, Chinese, etc. words.