### PR TITLE
Added nord theme

### DIFF
--- a/src-content/themes/_nord.scss
+++ b/src-content/themes/_nord.scss
@@ -1,0 +1,9 @@
+#__stutter.theme-nord {
+  --barBG: #2e3440;
+  --barBorder: #434c5e;
+  --progressColor: #3b4252;
+  --textColor: #e5e9f0;
+  --textHighlight: #b48ead;
+  --buttonColor: #81a1c1;
+  --pausedTextColor: rgba(255, 255, 255, 0.5);
+}

--- a/src-content/themes/_themes.scss
+++ b/src-content/themes/_themes.scss
@@ -5,3 +5,4 @@
 @import "gameboy";
 @import "hacktoberfest";
 @import "solarized";
+@import "nord";

--- a/src-options/index.html
+++ b/src-options/index.html
@@ -22,6 +22,7 @@
 					<option value="gameboy">Gameboy</option>
 					<option value="hacktoberfest">Hacktoberfest</option>
 					<option value="solarized">Solarized</option>
+					<option value="nord">Nord</option>
 				</select>
 			</label>
 			<p>When beginning to Stutter, the <strong>Slow Start Count</strong> will ease you in by slowly ramping up to full speed over this many words. (Default 5)</p>


### PR DESCRIPTION
If you could also please add the label `hacktoberfest-accepted` to this if the PR gets merged, that would be awesome.
https://hacktoberfest.digitalocean.com/hacktoberfest-update

Here is what it looks like in action:
![Screen Shot 2020-10-06 at 1 06 45 PM (2)](https://user-images.githubusercontent.com/5826776/95242980-7a9b8700-07ff-11eb-998e-4354a6432650.png)

Uses the Nord Theme from here:
https://nordtheme.com/